### PR TITLE
Fix #788: Using instanceof in BC library fails for public key

### DIFF
--- a/powerauth-java-crypto/src/main/java/com/wultra/security/powerauth/crypto/lib/util/PqcDsaKeyConvertor.java
+++ b/powerauth-java-crypto/src/main/java/com/wultra/security/powerauth/crypto/lib/util/PqcDsaKeyConvertor.java
@@ -19,8 +19,6 @@ package com.wultra.security.powerauth.crypto.lib.util;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import org.bouncycastle.jcajce.provider.asymmetric.mldsa.BCMLDSAPrivateKey;
 import org.bouncycastle.jcajce.provider.asymmetric.mldsa.BCMLDSAPublicKey;
-import org.bouncycastle.jcajce.provider.asymmetric.mlkem.BCMLKEMPrivateKey;
-import org.bouncycastle.jcajce.provider.asymmetric.mlkem.BCMLKEMPublicKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/powerauth-java-crypto/src/main/java/com/wultra/security/powerauth/crypto/lib/util/PqcDsaKeyConvertor.java
+++ b/powerauth-java-crypto/src/main/java/com/wultra/security/powerauth/crypto/lib/util/PqcDsaKeyConvertor.java
@@ -17,6 +17,10 @@
 package com.wultra.security.powerauth.crypto.lib.util;
 
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import org.bouncycastle.jcajce.provider.asymmetric.mldsa.BCMLDSAPrivateKey;
+import org.bouncycastle.jcajce.provider.asymmetric.mldsa.BCMLDSAPublicKey;
+import org.bouncycastle.jcajce.provider.asymmetric.mlkem.BCMLKEMPrivateKey;
+import org.bouncycastle.jcajce.provider.asymmetric.mlkem.BCMLKEMPublicKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +66,9 @@ public class PqcDsaKeyConvertor {
         if (publicKey == null) {
             throw new GenericCryptoException("Missing public key");
         }
+        if (!publicKey.getClass().getName().equals(BCMLDSAPublicKey.class.getName())) {
+            throw new GenericCryptoException("Invalid public key");
+        }
         return publicKey.getEncoded();
     }
 
@@ -96,6 +103,9 @@ public class PqcDsaKeyConvertor {
     public byte[] convertPrivateKeyToBytes(PrivateKey privateKey) throws GenericCryptoException {
         if (privateKey == null) {
             throw new GenericCryptoException("Missing private key");
+        }
+        if (!privateKey.getClass().getName().equals(BCMLDSAPrivateKey.class.getName())) {
+            throw new GenericCryptoException("Invalid public key");
         }
         return privateKey.getEncoded();
     }

--- a/powerauth-java-crypto/src/main/java/com/wultra/security/powerauth/crypto/lib/util/PqcKemKeyConvertor.java
+++ b/powerauth-java-crypto/src/main/java/com/wultra/security/powerauth/crypto/lib/util/PqcKemKeyConvertor.java
@@ -95,11 +95,7 @@ public class PqcKemKeyConvertor {
         }
         try {
             final KeyFactory keyFactory = KeyFactory.getInstance(algorithmName, "BC");
-            final PublicKey publicKey = keyFactory.generatePublic(new X509EncodedKeySpec(publicKeyBytes));
-            if (!publicKey.getClass().getName().equals(BCMLKEMPublicKey.class.getName())) {
-                throw new GenericCryptoException("Invalid public key");
-            }
-            return publicKey;
+            return keyFactory.generatePublic(new X509EncodedKeySpec(publicKeyBytes));
         } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeySpecException e) {
             throw new GenericCryptoException("Public key conversion failed", e);
         }
@@ -117,11 +113,7 @@ public class PqcKemKeyConvertor {
         }
         try {
             final KeyFactory keyFactory = KeyFactory.getInstance(algorithmName, "BC");
-            final PrivateKey privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
-            if (!privateKey.getClass().getName().equals(BCMLKEMPrivateKey.class.getName())) {
-                throw new GenericCryptoException("Invalid private key");
-            }
-            return privateKey;
+            return keyFactory.generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
         } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeySpecException e) {
             throw new GenericCryptoException("Private key conversion failed", e);
         }

--- a/powerauth-java-crypto/src/main/java/com/wultra/security/powerauth/crypto/lib/util/PqcKemKeyConvertor.java
+++ b/powerauth-java-crypto/src/main/java/com/wultra/security/powerauth/crypto/lib/util/PqcKemKeyConvertor.java
@@ -17,8 +17,8 @@
 package com.wultra.security.powerauth.crypto.lib.util;
 
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
-import org.bouncycastle.jcajce.interfaces.MLKEMPrivateKey;
-import org.bouncycastle.jcajce.interfaces.MLKEMPublicKey;
+import org.bouncycastle.jcajce.provider.asymmetric.mlkem.BCMLKEMPrivateKey;
+import org.bouncycastle.jcajce.provider.asymmetric.mlkem.BCMLKEMPublicKey;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -61,7 +61,7 @@ public class PqcKemKeyConvertor {
         if (publicKey == null) {
             throw new GenericCryptoException("Missing public key");
         }
-        if (!(publicKey instanceof MLKEMPublicKey)) {
+        if (!publicKey.getClass().getName().equals(BCMLKEMPublicKey.class.getName())) {
             throw new GenericCryptoException("Invalid public key");
         }
         return publicKey.getEncoded();
@@ -77,10 +77,10 @@ public class PqcKemKeyConvertor {
         if (privateKey == null) {
             throw new GenericCryptoException("Missing private key");
         }
-        if (!(privateKey instanceof MLKEMPrivateKey mlkemPrivateKey)) {
+        if (!privateKey.getClass().getName().equals(BCMLKEMPrivateKey.class.getName())) {
             throw new GenericCryptoException("Invalid private key");
         }
-        return mlkemPrivateKey.getEncoded();
+        return privateKey.getEncoded();
     }
 
     /**
@@ -96,7 +96,7 @@ public class PqcKemKeyConvertor {
         try {
             final KeyFactory keyFactory = KeyFactory.getInstance(algorithmName, "BC");
             final PublicKey publicKey = keyFactory.generatePublic(new X509EncodedKeySpec(publicKeyBytes));
-            if (!(publicKey instanceof MLKEMPublicKey)) {
+            if (!publicKey.getClass().getName().equals(BCMLKEMPublicKey.class.getName())) {
                 throw new GenericCryptoException("Invalid public key");
             }
             return publicKey;
@@ -118,7 +118,7 @@ public class PqcKemKeyConvertor {
         try {
             final KeyFactory keyFactory = KeyFactory.getInstance(algorithmName, "BC");
             final PrivateKey privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
-            if (!(privateKey instanceof MLKEMPrivateKey)) {
+            if (!privateKey.getClass().getName().equals(BCMLKEMPrivateKey.class.getName())) {
                 throw new GenericCryptoException("Invalid private key");
             }
             return privateKey;


### PR DESCRIPTION
Use a classloader-safe way of checking key types.