### PR TITLE
Fix #835: Remove unused authentication code types from documentation

### DIFF
--- a/docs/Computing-and-Validating-Authentication-Codes.md
+++ b/docs/Computing-and-Validating-Authentication-Codes.md
@@ -72,26 +72,18 @@ The biometry factor can be added or removed using the [dynamic factor keys](./Dy
 
 ## Computing the authentication code
 
-PowerAuth authentication code is in principle multi-factor. It uses factor keys as derived above. The authentication code may include one, two or three factors, therefore achieving 1FA, 2FA or 3FA. In order to determine the type of the authentication code, following constants are used:
+PowerAuth authentication code is in principle multifactor. It uses factor keys as derived above. The authentication code may include one or two factors, therefore achieving 1FA or 2FA. In order to determine the type of the authentication code, following constants are used:
 
 - **1FA** - only a single factor is used
 	- `possession` - Authentication code uses only possession related key `KEY_AUTHENTICATION_CODE_POSSESSION`.
-	- `knowledge` - Authentication code uses only knowledge related key `KEY_AUTHENTICATION_CODE_KNOWLEDGE`.
-	- `biometry` - Authentication code uses only biometry related key `KEY_AUTHENTICATION_CODE_BIOMETRY`.
 - **2FA** - possession and one another factor is used
 	- `possession_knowledge` - Authentication code uses two keys: a possession related key `KEY_AUTHENTICATION_CODE_POSSESSION` and then knowledge related key `KEY_AUTHENTICATION_CODE_KNOWLEDGE`.
 	- `possession_biometry` - Authentication code uses two keys: a possession related key `KEY_AUTHENTICATION_CODE_POSSESSION` and then biometry related key `KEY_AUTHENTICATION_CODE_BIOMETRY`.
-- **3FA** - all three factors are used
-	- `possession_knowledge_biometry` - Authentication code uses three keys: a possession related key `KEY_AUTHENTICATION_CODE_POSSESSION`, then knowledge related key `KEY_AUTHENTICATION_CODE_KNOWLEDGE`, and finally biometry related key `KEY_AUTHENTICATION_CODE_BIOMETRY`.
-
-<!-- begin box info -->
-While all values are possible to use, only the values `possession`, `possession_knowledge` and `possession_biometry` are used in any practical setup.
-<!-- end -->
 
 When using more than one factor key, the keys are added additively in the authentication algorithm, so that the factors can be validated individually. The resulting PowerAuth authentication code can be then represented in two different formats:
 
-1. For online validation, the PowerAuth authentication code is one Base64 string. The length depends on the number of factors involved in the calculation (32, 64 or 96 bytes encoded in Base64).
-1. For offline validation purposes, the PowerAuth authentication code is a sequence of one to three numeric strings with configurable amount of digits, each sequence is separated by "-" character.
+1. For online validation, the PowerAuth authentication code is one Base64 string. The length depends on the number of factors involved in the calculation (32 or 64 bytes encoded in Base64).
+1. For offline validation purposes, the PowerAuth authentication code is a sequence of one or two numeric strings with configurable amount of digits, each sequence is separated by "-" character.
 
 Both formats share the same core algorithm to calculate the authentication code components:
 
@@ -213,7 +205,7 @@ byte[] CTR_DATA_next = Hash.sha3_256(CTR_DATA);
 
 ### Loop Unrolling
 
-The following examples explain how multi-factor authentication code components are derived from factor keys in the protocol. The core idea is that each additional factor extends a KMAC-based derivation chain, where `CTR_DATA` is always part of the input and `||` denotes byte concatenation. For 1F, the derived key is computed directly from `CTR_DATA` using factor 0 and then used to compute the MAC over request data. For 2F and 3F, the derivation becomes nested, so that factor 1 depends on the result of factor 0, and factor 2 depends on the result of factor 1 (which already includes factor 0). This chaining binds factors together in a deterministic order and ensures that the resulting authentication code cannot be computed or validated correctly unless all required factors are available.
+The following examples explain how multifactor authentication code components are derived from factor keys in the protocol. The core idea is that each additional factor extends a KMAC-based derivation chain, where `CTR_DATA` is always part of the input and `||` denotes byte concatenation. For 1F, the derived key is computed directly from `CTR_DATA` using factor 0 and then used to compute the MAC over request data. For 2F the derivation becomes nested, so that factor 1 depends on the result of factor 0. This chaining binds factors together in a deterministic order and ensures that the resulting authentication code cannot be computed or validated correctly unless all required factors are available.
 
 #### 1F component
 
@@ -233,18 +225,6 @@ DERIVED_KEY = KMAC(key: FACTOR_KEYS[1],
                               data: CTR_DATA))
 
 MAC = KMAC(key: DERIVED_KEY, data: DATA)
-```
-
-#### 3F component
-
-```
-DERIVED_KEY = KMAC(key: FACTOR_KEYS[2], 
-                   data: CTR_DATA ||
-                         KMAC(key: FACTOR_KEYS[1],
-                              data: CTR_DATA || 
-                                    KMAC(key: FACTOR_KEYS[0],
-                                         data: CTR_DATA)))
-MAC = KMAC(key: DERIVED_KEY, data: DATA)    
 ```
 
 ## Validating the authentication code

--- a/docs/Standard-RESTful-API.md
+++ b/docs/Standard-RESTful-API.md
@@ -588,7 +588,6 @@ The following authentication code types are supported:
 
 - `possession_knowledge`
 - `possession_biometry`
-- `possession_knowledge_biometry`
 
 The request body should contain data used for computing the authentication code.
 


### PR DESCRIPTION
Remove mentions from documentation in 2.0.0 release