### PR TITLE
fix #936: register lombok annotation processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+        <lombok.version>1.18.46</lombok.version>
         <slf4j.version>2.0.18</slf4j.version>
         <junit.version>6.0.3</junit.version>
     </properties>
@@ -123,6 +124,15 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
+                    <configuration>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
+                                <version>${lombok.version}</version>
+                            </path>
+                        </annotationProcessorPaths>
+                    </configuration>
                 </plugin>
 
                 <plugin>

--- a/powerauth-java-crypto/pom.xml
+++ b/powerauth-java-crypto/pom.xml
@@ -82,7 +82,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.46</version>
+			<version>${lombok.version}</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
## Description

Registered Lombok as an explicit annotation processor in the root Maven compiler plugin configuration. The existing module Lombok dependency now reuses the parent `lombok.version` property.

## Motivation and Context

Java 25 no longer enables implicit annotation processor discovery by default, so Lombok-generated members may be unavailable during compilation. Explicitly configuring Lombok in `annotationProcessorPaths` keeps local Java 25 builds working.

## Closes

Closes #936