### PR TITLE
Fix #949: Validate request and response nonces in AEAD

### DIFF
--- a/powerauth-java-crypto/src/main/java/com/wultra/security/powerauth/crypto/lib/v4/encryptor/aead/AeadRequestResponseValidator.java
+++ b/powerauth-java-crypto/src/main/java/com/wultra/security/powerauth/crypto/lib/v4/encryptor/aead/AeadRequestResponseValidator.java
@@ -18,11 +18,14 @@
 package com.wultra.security.powerauth.crypto.lib.v4.encryptor.aead;
 
 import com.wultra.security.powerauth.crypto.lib.encryptor.RequestResponseValidator;
+import com.wultra.security.powerauth.crypto.lib.util.ByteUtils;
+import com.wultra.security.powerauth.crypto.lib.util.SideChannelUtils;
 import com.wultra.security.powerauth.crypto.lib.v4.encryptor.exception.AeadException;
 import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.request.AeadEncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
 import lombok.Getter;
 
+import java.util.Base64;
 import java.util.Set;
 
 /**
@@ -37,6 +40,12 @@ public class AeadRequestResponseValidator implements RequestResponseValidator<Ae
      * Protocol versions supported in this validator.
      */
     private final static Set<String> supportedVersions = Set.of("4.0");
+
+    /**
+     * Expected length of the combined request nonce in bytes. The first 12 bytes are used as the IV for the request
+     * encryption, the last 12 bytes are used as the IV for the response encryption.
+     */
+    private final static int NONCE_LENGTH = 24;
 
     /**
      * Construct validator for particular protocol version.
@@ -68,6 +77,9 @@ public class AeadRequestResponseValidator implements RequestResponseValidator<Ae
         if (request.getNonce() == null) {
             return false;
         }
+        if (!validateNonce(request.getNonce())) {
+            return false;
+        }
         return request.getTimestamp() != null;
     }
 
@@ -80,6 +92,34 @@ public class AeadRequestResponseValidator implements RequestResponseValidator<Ae
             return false;
         }
         return response.getTimestamp() != null;
+    }
+
+    /**
+     * Validate the combined request nonce. The server uses the first half of the nonce as the IV for decrypting the
+     * request and the second half as the IV for encrypting the response, both under the same envelope key. The two
+     * halves must therefore differ, otherwise the IV would be reused with the same key during the communication, which
+     * would break the security guarantees of the AEAD scheme.
+     *
+     * @param nonceBase64 Base64-encoded combined request nonce.
+     * @return {@code true} if the nonce has the expected length and the request and response nonce halves differ.
+     */
+    private boolean validateNonce(String nonceBase64) {
+        if (nonceBase64 == null) {
+            return false;
+        }
+        final byte[] nonce;
+        try {
+            nonce = Base64.getDecoder().decode(nonceBase64);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+        if (nonce.length != NONCE_LENGTH) {
+            return false;
+        }
+        final byte[] requestNonce = ByteUtils.subarray(nonce, 0, NONCE_LENGTH / 2);
+        final byte[] responseNonce = ByteUtils.subarray(nonce, NONCE_LENGTH / 2, NONCE_LENGTH / 2);
+        // The request nonce must differ from the response nonce to avoid IV reuse under the same envelope key
+        return !SideChannelUtils.constantTimeAreEqual(requestNonce, responseNonce);
     }
     
 }

--- a/powerauth-java-crypto/src/test/java/com/wultra/security/powerauth/crypto/lib/v4/encryptor/aead/AeadRequestResponseValidatorTest.java
+++ b/powerauth-java-crypto/src/test/java/com/wultra/security/powerauth/crypto/lib/v4/encryptor/aead/AeadRequestResponseValidatorTest.java
@@ -89,6 +89,7 @@ class AeadRequestResponseValidatorTest {
     void requestWithMalformedBase64NonceIsRejected() {
         final AeadEncryptedRequest request = request("not-valid-base64!!!");
         assertFalse(validator.validateEncryptedRequest(request));
+        assertFalse(validator.validateEncryptedRequestWithoutData(request));
     }
 
     @Test

--- a/powerauth-java-crypto/src/test/java/com/wultra/security/powerauth/crypto/lib/v4/encryptor/aead/AeadRequestResponseValidatorTest.java
+++ b/powerauth-java-crypto/src/test/java/com/wultra/security/powerauth/crypto/lib/v4/encryptor/aead/AeadRequestResponseValidatorTest.java
@@ -94,6 +94,7 @@ class AeadRequestResponseValidatorTest {
     void requestWithNullNonceIsRejected() {
         final AeadEncryptedRequest request = request(null);
         assertFalse(validator.validateEncryptedRequest(request));
+        assertFalse(validator.validateEncryptedRequestWithoutData(request));
     }
 
     @Test

--- a/powerauth-java-crypto/src/test/java/com/wultra/security/powerauth/crypto/lib/v4/encryptor/aead/AeadRequestResponseValidatorTest.java
+++ b/powerauth-java-crypto/src/test/java/com/wultra/security/powerauth/crypto/lib/v4/encryptor/aead/AeadRequestResponseValidatorTest.java
@@ -82,6 +82,7 @@ class AeadRequestResponseValidatorTest {
         final String longNonce = Base64.getEncoder().encodeToString(new byte[48]);
         final AeadEncryptedRequest request = request(longNonce);
         assertFalse(validator.validateEncryptedRequest(request));
+        assertFalse(validator.validateEncryptedRequestWithoutData(request));
     }
 
     @Test

--- a/powerauth-java-crypto/src/test/java/com/wultra/security/powerauth/crypto/lib/v4/encryptor/aead/AeadRequestResponseValidatorTest.java
+++ b/powerauth-java-crypto/src/test/java/com/wultra/security/powerauth/crypto/lib/v4/encryptor/aead/AeadRequestResponseValidatorTest.java
@@ -74,6 +74,7 @@ class AeadRequestResponseValidatorTest {
         final String shortNonce = Base64.getEncoder().encodeToString(new byte[12]);
         final AeadEncryptedRequest request = request(shortNonce);
         assertFalse(validator.validateEncryptedRequest(request));
+        assertFalse(validator.validateEncryptedRequestWithoutData(request));
     }
 
     @Test

--- a/powerauth-java-crypto/src/test/java/com/wultra/security/powerauth/crypto/lib/v4/encryptor/aead/AeadRequestResponseValidatorTest.java
+++ b/powerauth-java-crypto/src/test/java/com/wultra/security/powerauth/crypto/lib/v4/encryptor/aead/AeadRequestResponseValidatorTest.java
@@ -1,0 +1,153 @@
+/*
+ * PowerAuth Crypto Library
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.wultra.security.powerauth.crypto.lib.v4.encryptor.aead;
+
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.exception.AeadException;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.request.AeadEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link AeadRequestResponseValidator}, in particular the combined request nonce validation that prevents
+ * IV reuse between the request and response encryption.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+class AeadRequestResponseValidatorTest {
+
+    private static final String TEMPORARY_KEY_ID = "temp-key-id";
+    private static final String ENCRYPTED_DATA = "ZW5jcnlwdGVkRGF0YQ==";
+    private static final long TIMESTAMP = 1717500000000L;
+
+    private AeadRequestResponseValidator validator;
+
+    @BeforeEach
+    void setUp() throws AeadException {
+        validator = new AeadRequestResponseValidator("4.0");
+    }
+
+    @Test
+    void constructorRejectsUnsupportedProtocolVersion() {
+        assertThrows(AeadException.class, () -> new AeadRequestResponseValidator("3.3"));
+    }
+
+    @Test
+    void validRequestPasses() {
+        final AeadEncryptedRequest request = request(nonce(repeat((byte) 0x01), repeat((byte) 0x02)));
+        assertTrue(validator.validateEncryptedRequest(request));
+        assertTrue(validator.validateEncryptedRequestWithoutData(request));
+    }
+
+    @Test
+    void requestWithEqualNonceHalvesIsRejected() {
+        // Request nonce equal to response nonce would reuse the IV under the same envelope key
+        final byte[] half = repeat((byte) 0x07);
+        final AeadEncryptedRequest request = request(nonce(half, half));
+        assertFalse(validator.validateEncryptedRequest(request));
+        assertFalse(validator.validateEncryptedRequestWithoutData(request));
+    }
+
+    @Test
+    void requestWithTooShortNonceIsRejected() {
+        final String shortNonce = Base64.getEncoder().encodeToString(new byte[12]);
+        final AeadEncryptedRequest request = request(shortNonce);
+        assertFalse(validator.validateEncryptedRequest(request));
+    }
+
+    @Test
+    void requestWithTooLongNonceIsRejected() {
+        final String longNonce = Base64.getEncoder().encodeToString(new byte[48]);
+        final AeadEncryptedRequest request = request(longNonce);
+        assertFalse(validator.validateEncryptedRequest(request));
+    }
+
+    @Test
+    void requestWithMalformedBase64NonceIsRejected() {
+        final AeadEncryptedRequest request = request("not-valid-base64!!!");
+        assertFalse(validator.validateEncryptedRequest(request));
+    }
+
+    @Test
+    void requestWithNullNonceIsRejected() {
+        final AeadEncryptedRequest request = request(null);
+        assertFalse(validator.validateEncryptedRequest(request));
+    }
+
+    @Test
+    void requestWithNullTemporaryKeyIdIsRejected() {
+        final AeadEncryptedRequest request = new AeadEncryptedRequest(null, ENCRYPTED_DATA, nonce(repeat((byte) 0x01), repeat((byte) 0x02)), TIMESTAMP);
+        assertFalse(validator.validateEncryptedRequest(request));
+    }
+
+    @Test
+    void requestWithNullTimestampIsRejected() {
+        final AeadEncryptedRequest request = new AeadEncryptedRequest(TEMPORARY_KEY_ID, ENCRYPTED_DATA, nonce(repeat((byte) 0x01), repeat((byte) 0x02)), null);
+        assertFalse(validator.validateEncryptedRequest(request));
+    }
+
+    @Test
+    void requestWithoutEncryptedDataFailsFullValidationButPassesWithoutData() {
+        final AeadEncryptedRequest request = new AeadEncryptedRequest(TEMPORARY_KEY_ID, null, nonce(repeat((byte) 0x01), repeat((byte) 0x02)), TIMESTAMP);
+        assertFalse(validator.validateEncryptedRequest(request));
+        assertTrue(validator.validateEncryptedRequestWithoutData(request));
+    }
+
+    @Test
+    void nullRequestIsRejected() {
+        assertFalse(validator.validateEncryptedRequest(null));
+        assertFalse(validator.validateEncryptedRequestWithoutData(null));
+    }
+
+    @Test
+    void validResponsePasses() {
+        final AeadEncryptedResponse response = new AeadEncryptedResponse(ENCRYPTED_DATA, TIMESTAMP);
+        assertTrue(validator.validateEncryptedResponse(response));
+    }
+
+    @Test
+    void responseWithoutDataOrTimestampIsRejected() {
+        assertFalse(validator.validateEncryptedResponse(null));
+        assertFalse(validator.validateEncryptedResponse(new AeadEncryptedResponse(null, TIMESTAMP)));
+        assertFalse(validator.validateEncryptedResponse(new AeadEncryptedResponse(ENCRYPTED_DATA, null)));
+    }
+
+    private static AeadEncryptedRequest request(String nonce) {
+        return new AeadEncryptedRequest(TEMPORARY_KEY_ID, ENCRYPTED_DATA, nonce, TIMESTAMP);
+    }
+
+    private static String nonce(byte[] requestNonce, byte[] responseNonce) {
+        final byte[] combined = new byte[requestNonce.length + responseNonce.length];
+        System.arraycopy(requestNonce, 0, combined, 0, requestNonce.length);
+        System.arraycopy(responseNonce, 0, combined, requestNonce.length, responseNonce.length);
+        return Base64.getEncoder().encodeToString(combined);
+    }
+
+    private static byte[] repeat(byte value) {
+        final byte[] result = new byte[12];
+        Arrays.fill(result, value);
+        return result;
+    }
+
+}


### PR DESCRIPTION
Additional validation of request/response nonces and related validator tests.