### PR TITLE
Fix #951: Consolidate CHANGELOG.md and add Copilot changelog instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,48 @@
+# Copilot Instructions — powerauth-crypto
+
+This file captures conventions used when working with GitHub Copilot in the `powerauth-crypto`
+repository and the broader Wultra PowerAuth ecosystem.
+
+---
+
+## Changelog
+
+`CHANGELOG.md` lives at the **repo root**. Update it as part of every PR — before creating the PR,
+not after merge.
+
+### Format
+
+Follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/):
+
+```markdown
+# Changelog
+
+## X.Y.Z (TBA)
+### Added
+- New feature description [(#N)](https://github.com/wultra/powerauth-crypto/issues/N)
+
+### Changed
+- Changed behaviour description [(#N)](...)
+
+### Fixed
+- Bug fix description [(#N)](...)
+
+## 1.2.3 - 2025-03-01
+### Added
+- ...
+```
+
+**Change type subsections** (use only those that apply):
+- `Added` — new features
+- `Changed` — changes in existing functionality
+- `Deprecated` — soon-to-be removed features
+- `Removed` — removed features
+- `Fixed` — bug fixes
+- `Security` — security vulnerability fixes
+
+**Rules:**
+- Always add new entries under `## X.Y.Z (TBA)` (the unreleased section at the top).
+- On release, rename `## X.Y.Z (TBA)` to `## x.y.z - YYYY-MM-DD` (ISO 8601 date).
+- Each entry: `- <Description starting with verb> [(#N)](https://github.com/wultra/powerauth-crypto/issues/N)` — link to the issue, not the PR.
+- Descriptions should be human-readable, not raw commit messages (e.g. "Fixed NPE when application list is empty" not "fix #811: add missing import").
+- Skip the Changelog update only for changes with no user-visible impact (e.g. pure CI/tooling changes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 2.2.0
+All notable changes to this project are documented in this file, following the
+[Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format.
+
+## 2.2.0 (TBA)
 ### Added
 - Add documentation for UKE [(#930)](https://github.com/wultra/powerauth-crypto/issues/930)
 - Add request and response nonce validation [(#949)](https://github.com/wultra/powerauth-crypto/issues/949)


### PR DESCRIPTION
## Description

Brings `powerauth-crypto` in line with the Wultra changelog and Copilot conventions (parent epic wultra/tasklist#986), matching the `iap-server` canonical references:

- **`CHANGELOG.md`** — reformatted to [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/): added the format intro line and renamed the top section to the unreleased `## 2.2.0 (TBA)` marker. Existing release history and issue links are preserved.
- **`.github/copilot-instructions.md`** — new file documenting the changelog conventions (format, change-type subsections, rules), adapted from the `iap-server` reference with `powerauth-crypto`-specific repository name and issue URLs.

## Motivation and Context

Standardizes the changelog format and codifies the convention so future contributions (and Copilot) follow Keep a Changelog 1.1.0 consistently across the Wultra ecosystem.

## Closes

Closes #951
