### PR TITLE
Fix #951: Align CHANGELOG.md with strict Keep a Changelog 1.1.0 format

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,12 +12,19 @@ not after merge.
 
 ### Format
 
-Follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/):
+Follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) **strictly**. The header must
+mention both Keep a Changelog and Semantic Versioning, the file must contain a `## [Unreleased]`
+section, and all version/section headings must be linkable via reference-style links at the bottom:
 
 ```markdown
 # Changelog
 
-## X.Y.Z (TBA)
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
 ### Added
 - New feature description [(#N)](https://github.com/wultra/powerauth-crypto/issues/N)
 
@@ -27,9 +34,12 @@ Follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/):
 ### Fixed
 - Bug fix description [(#N)](...)
 
-## 1.2.3 - 2025-03-01
+## [1.2.3] - 2025-03-01
 ### Added
 - ...
+
+[unreleased]: https://github.com/wultra/powerauth-crypto/compare/1.2.3...HEAD
+[1.2.3]: https://github.com/wultra/powerauth-crypto/compare/1.2.2...1.2.3
 ```
 
 **Change type subsections** (use only those that apply):
@@ -41,8 +51,10 @@ Follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/):
 - `Security` — security vulnerability fixes
 
 **Rules:**
-- Always add new entries under `## X.Y.Z (TBA)` (the unreleased section at the top).
-- On release, rename `## X.Y.Z (TBA)` to `## x.y.z - YYYY-MM-DD` (ISO 8601 date).
+- Header must mention both [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- Always add new entries under the `## [Unreleased]` section at the top.
+- On release: rename `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD` (ISO 8601 date), add a fresh empty `## [Unreleased]` section above it, update the `[unreleased]` reference link, and add the new version's compare link.
+- Versions and sections must be linkable via reference-style links at the bottom of the file.
 - Each entry: `- <Description starting with verb> [(#N)](https://github.com/wultra/powerauth-crypto/issues/N)` — link to the issue, not the PR.
 - Descriptions should be human-readable, not raw commit messages (e.g. "Fixed NPE when application list is empty" not "fix #811: add missing import").
 - Skip the Changelog update only for changes with no user-visible impact (e.g. pure CI/tooling changes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-All notable changes to this project are documented in this file, following the
-[Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format.
+All notable changes to this project will be documented in this file.
 
-## 2.2.0 (TBA)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
 ### Added
 - Add documentation for UKE [(#930)](https://github.com/wultra/powerauth-crypto/issues/930)
 - Add request and response nonce validation [(#949)](https://github.com/wultra/powerauth-crypto/issues/949)
@@ -15,3 +17,5 @@ All notable changes to this project are documented in this file, following the
 
 ### Fixed
 - Use BC provider for TOTP instead of default JCA [(#934)](https://github.com/wultra/powerauth-crypto/issues/934)
+
+[unreleased]: https://github.com/wultra/powerauth-crypto/compare/2.1.0...HEAD


### PR DESCRIPTION
## Description

Re-aligns `powerauth-crypto` with the **strict** [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format mandated by the parent epic wultra/tasklist#986 (issue #951 was reopened for this re-alignment):

- **`CHANGELOG.md`**
  - Header now mentions both Keep a Changelog **and** [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  - Replaced the `## 2.2.0 (TBA)` heading with a `## [Unreleased]` section (2.2.0 is still a `-SNAPSHOT`).
  - Added a reference-style `[unreleased]` compare link at the bottom (`2.1.0...HEAD`).
  - All existing entries and their issue links are preserved.
- **`.github/copilot-instructions.md`** — updated the Changelog section to the strict format: KaCL + Semantic Versioning header, `## [Unreleased]` section, linkable version headings, and the full release procedure.

## Motivation and Context

The previous version followed an earlier draft convention (`## X.Y.Z (TBA)`, no Semantic Versioning mention, no linkable versions). The epic standardizes all Wultra PowerAuth repositories on the strict Keep a Changelog 1.1.0 format.

## Closes

Closes #951
